### PR TITLE
Fix probable typos in push notification cert docs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -115,7 +115,7 @@ This certificate is used by your backend server to authenticate the sending of p
 
 #### App Store and Ad Hoc
 
-This certificate is used by your machine to sign applications for distribution. This certificate is required if you are publishing to the App store, distributing an IPA file or testing the app with internal or external testers in TestFlight.    
+This certificate is used by your machine to sign applications for distribution. This certificate is required if you are publishing to the App store, distributing an IPA file or testing the app with internal or external testers in TestFlight.
 
 > WARNING: Applications distributed as Ad Hoc / TestFlight / HockeyApp will expire.
 
@@ -128,7 +128,18 @@ This certificate is used by your machine to sign applications for distribution. 
 
 #### Apple Push Notification service SSL (Sandbox)
 
-This certificate is used by your backend server to authenticate the sending of push notifications using Apple Push Notification Service.
+This certificate is used by your backend DEVELOPMENT server to authenticate the sending of push notifications using Apple Push Notification Service.
+
+- **Type**: Push
+- **Environment**: App Store
+- **Personal**: No
+- **Shared with team**: Yes
+- **App specific**: Yes
+- **Creation, Backup & Restore guide**: [Link](/guide/certificates/apple-push-notification-service-ssl-sandbox.md)
+
+#### Apple Push Notification service SSL (Sandbox & Production)
+
+This certificate is used by your backend PRODUCTION server to authenticate the sending of push notifications using Apple Push Notification Service.
 
 - **Type**: Push
 - **Environment**: App Store

--- a/guide/certificates/apple-push-notification-service-ssl-sandbox.md
+++ b/guide/certificates/apple-push-notification-service-ssl-sandbox.md
@@ -25,11 +25,11 @@ Creating a new certificate will invalidate the previous one and should only be d
 
 - Click the plus icon to add a new iOS Certificate
 
-- Select **iOS App Development** and continue through to the CSR upload screen
+- Select **Apple Push Notification service SSL (Sandbox)** and continue through to the CSR upload screen
 
 - Upload your `CertificateSigningRequest.certSigningRequest` file then click generate
 
-- Click download and save the file as `certificates/apn/{app_bundle_id}/sandbox/ios_distribution.cer`
+- Click download and save the file as `certificates/apn/{app_bundle_id}/sandbox/aps_sandbox.cer`
 
 - Open the file, this should launch Keychain Access. You can verify that your certificate has installed if you see the certificate
 
@@ -40,6 +40,12 @@ Creating a new certificate will invalidate the previous one and should only be d
 - Select this certificate then go to `File > Export Items` and save this file as `certificates/apn/{app_bundle_id}/sandbox/Certificates.p12`
 
 - Give this file a shared password (or leave blank if the repository is private)
+
+## Convert your shared certificate to PEM format
+
+- This uses the `openssl` library to generate a passwordless file that contains the signed certificate and its private key:
+
+    openssl pkcs12 -in Certificates.p12 -out apn_sandbox.pem -nodes
 
 ## Restore your shared certificate
 

--- a/guide/certificates/apple-push-notification-service-ssl.md
+++ b/guide/certificates/apple-push-notification-service-ssl.md
@@ -1,4 +1,4 @@
-# Setup Apple Push Notification Service SSL
+# Setup Apple Push Notification Service SSL (Sandbox & Production)
 
 ## Important
 
@@ -12,7 +12,7 @@ Creating a new certificate will invalidate the previous one and should only be d
 
 - Within the Keychain Access drop down menu, select Keychain Access > Certificate Assistant > Request a Certificate from a Certificate Authority.
 
-- In the Certificate Information window, en§ter the following information:
+- In the Certificate Information window, enter the following information:
   - In the User Email Address field, enter the **shared email address** (e.g. info@mycompany.com).
   - In the Common Name field, create a name for your shared key (e.g. **Simpleweb LTD**).
   - The CA Email Address field should be left empty.
@@ -29,7 +29,7 @@ Creating a new certificate will invalidate the previous one and should only be d
 
 - Upload your `CertificateSigningRequest.certSigningRequest` file then click generate
 
-- Click download and save the file as `certificates/apn/{app_bundle_id}/production/ios_distribution.cer`
+- Click download and save the file as `certificates/apn/{app_bundle_id}/production/aps_production.cer`
 
 - Open the file, this should launch Keychain Access. You can verify that your certificate has installed if you see the certificate
 
@@ -40,6 +40,12 @@ Creating a new certificate will invalidate the previous one and should only be d
 - Select this certificate then go to `File > Export Items` and save this file as `certificates/apn/{app_bundle_id}/production/Certificates.p12`
 
 - Give this file a shared password (or leave blank if the repository is private)
+
+## Convert your shared certificate to PEM format
+
+- This uses the `openssl` library to generate a passwordless file that contains the signed certificate and its private key:
+
+    openssl pkcs12 -in Certificates.p12 -out apn_production.pem -nodes
 
 ## Restore your shared certificate
 


### PR DESCRIPTION
and link both the sandbox and production docs from README

It looks like the original author copy-pasted from the Distribution certs doc.

The most critical change I made is that instead of using the **iOS App Development** tool on ADC, we use the following tools:
* **Apple Push Notification service SSL (Sandbox)**
* **Apple Push Notification service SSL (Sandbox & Production)**